### PR TITLE
Feature/add product to favorites

### DIFF
--- a/src/getProducts.js
+++ b/src/getProducts.js
@@ -32,7 +32,7 @@ async function displayProductsCards(userID, favorites) {
       const $productCard = $(`
         <a href="/product?id=${doc.id}" class="hover:cursor-pointer border border-gray-300 rounded-md flex flex-col relative">
           <div class="absolute right-3 top-3 text-red-500" data-favorite>
-            <i id="save-${doc.id}" class="fa-regular fa-heart fa-xl"></i>
+            <i id="save-${doc.id}" class="fa-heart fa-xl"></i>
           </div>
 
           <div class="flex items-center justify-center grow-1">
@@ -54,6 +54,13 @@ async function displayProductsCards(userID, favorites) {
         </a>
       `);
 
+      const isInitiallyFavorited = favorites.includes(doc.id);
+      const iconClass = isInitiallyFavorited ? "fa-solid" : "fa-regular";
+
+      const icon = $productCard.find(".fa-heart");
+      icon.addClass(iconClass);
+      icon.removeClass(isInitiallyFavorited ? "fa-regular" : "fa-solid");
+
       // add to favorite
       $productCard.on("click", "[data-favorite]", async function (e) {
         e.preventDefault();
@@ -64,16 +71,6 @@ async function displayProductsCards(userID, favorites) {
         } else {
           showAlert("Product was removed from favorites!");
         }
-      });
-
-      // hover on add to favorite
-      $productCard.on("mouseenter", "[data-favorite]", function () {
-        $(this).find(".fa-heart").addClass("fa-solid");
-        $(this).find(".fa-heart").removeClass("fa-regular");
-      });
-      $productCard.on("mouseleave", "[data-favorite]", function () {
-        $(this).find(".fa-heart").addClass("fa-regular");
-        $(this).find(".fa-heart").removeClass("fa-solid");
       });
 
       // add to current list

--- a/src/getProducts.js
+++ b/src/getProducts.js
@@ -260,7 +260,7 @@ function showDashboard() {
   });
 }
 
-async function toggleFavorite(userID, docID) {
+export async function toggleFavorite(userID, docID) {
   const userRef = doc(db, "users", userID);
   const userSnap = await getDoc(userRef);
   const userData = userSnap.data() || {};

--- a/src/getProducts.js
+++ b/src/getProducts.js
@@ -53,15 +53,17 @@ async function displayProductsCards(userID, favorites) {
           </div>
         </a>
       `);
-
       const isFavorited = favorites.includes(doc.id);
-      const icon = $productCard.find(".fa-regular");
       // add to favorite
       $productCard.on("click", "[data-favorite]", function (e) {
         e.preventDefault();
         // TODO: add to favorite function here
         toggleFavorite(userID, doc.id);
-        console.log("Something happened?");
+        if (isFavorited) {
+          showAlert("Product was added to favorites!");
+        } else {
+          showAlert("Product was removed from favorites!");
+        }
       });
 
       // hover on add to favorite
@@ -276,11 +278,13 @@ async function toggleFavorite(userID, docID) {
     if (isFavorited) {
       // Remove from Firestore array
       await updateDoc(userRef, { favorites: arrayRemove(docID) });
-      icon.classList.replace("fa-solid", "fa-regular");
+      icon.classList.add("fa-solid");
+      icon.classList.remove("fa-regular");
     } else {
       // Add to Firestore array
       await updateDoc(userRef, { favorites: arrayUnion(docID) });
-      icon.classList.replace("fa-regular", "fa-solid");
+      icon.classList.add("fa-regular");
+      icon.classList.remove("fa-solid");
     }
   } catch (err) {
     console.error("Error toggling favorites:", err);

--- a/src/getProducts.js
+++ b/src/getProducts.js
@@ -53,12 +53,12 @@ async function displayProductsCards(userID, favorites) {
           </div>
         </a>
       `);
-      const isFavorited = favorites.includes(doc.id);
+
       // add to favorite
-      $productCard.on("click", "[data-favorite]", function (e) {
+      $productCard.on("click", "[data-favorite]", async function (e) {
         e.preventDefault();
         // TODO: add to favorite function here
-        toggleFavorite(userID, doc.id);
+        const isFavorited = await toggleFavorite(userID, doc.id);
         if (isFavorited) {
           showAlert("Product was added to favorites!");
         } else {
@@ -273,19 +273,23 @@ async function toggleFavorite(userID, docID) {
   const icon = document.getElementById(iconId);
 
   // JS function ".includes" will return true if an item is found in the array
-  const isFavorited = favorites.includes(docID);
+  const currentlyFavorited = favorites.includes(docID);
+  let newFavoritedState;
   try {
-    if (isFavorited) {
+    if (currentlyFavorited) {
       // Remove from Firestore array
       await updateDoc(userRef, { favorites: arrayRemove(docID) });
-      icon.classList.add("fa-solid");
-      icon.classList.remove("fa-regular");
+      icon.classList.add("fa-regular");
+      icon.classList.remove("fa-solid");
+      newFavoritedState = false;
     } else {
       // Add to Firestore array
       await updateDoc(userRef, { favorites: arrayUnion(docID) });
-      icon.classList.add("fa-regular");
-      icon.classList.remove("fa-solid");
+      icon.classList.add("fa-solid");
+      icon.classList.remove("fa-regular");
+      newFavoritedState = true;
     }
+    return newFavoritedState;
   } catch (err) {
     console.error("Error toggling favorites:", err);
   }

--- a/src/getProducts.js
+++ b/src/getProducts.js
@@ -182,10 +182,6 @@ async function displayPreviouslyAddedCards(userID) {
       historyRecord.content.forEach((product) => {
         const $productCard = $(`
           <a href="/product?id=${doc.id}" class="hover:cursor-pointer border border-gray-300 rounded-md flex flex-col relative">
-            <div class="absolute right-3 top-3 text-red-500" data-favorite>
-              <i class="fa-regular fa-heart fa-xl"></i>
-            </div>
-  
             <div class="flex items-center justify-center grow-1">
               <img src="${product.imageUrl}" class="" alt="${product.name}-image" />
             </div>
@@ -204,22 +200,6 @@ async function displayPreviouslyAddedCards(userID) {
             </div>
           </a>
         `);
-        // add to favorite
-        $productCard.on("click", "[data-favorite]", function (e) {
-          e.preventDefault();
-          // TODO: add to favorite function here 🔥
-        });
-
-        // hover on add to favorite
-        $productCard.on("mouseenter", "[data-favorite]", function () {
-          $(this).find(".fa-heart").addClass("fa-solid");
-          $(this).find(".fa-heart").removeClass("fa-regular");
-        });
-        $productCard.on("mouseleave", "[data-favorite]", function () {
-          $(this).find(".fa-heart").addClass("fa-regular");
-          $(this).find(".fa-heart").removeClass("fa-solid");
-        });
-
         // add to current list
         $productCard.on("click", "[data-add-to-list]", async function (e) {
           e.preventDefault();

--- a/src/search.js
+++ b/src/search.js
@@ -44,7 +44,6 @@ async function searchByKeyword(keyword = "", userID = "", favorites = []) {
       const product = doc.data();
       const docID = doc.id;
       const isInitiallyFavorited = favorites.includes(docID);
-      const iconClass = isInitiallyFavorited ? "fa-solid" : "fa-regular";
 
       const $productCard = $(`
         <a href="/product?id=${doc.id}" class="hover:cursor-pointer border border-gray-300 rounded-md flex flex-col relative">

--- a/src/store.js
+++ b/src/store.js
@@ -1,9 +1,18 @@
 import { db } from "./firebaseConfig.js";
-import { collection, getDocs, addDoc } from "firebase/firestore";
+import {
+  collection,
+  getDocs,
+  addDoc,
+  arrayUnion,
+  arrayRemove,
+  getDoc,
+  doc,
+} from "firebase/firestore";
 import { addProductToCurrentList } from "./db.js";
 import $ from "jquery";
-
-import { doc, getDoc } from "firebase/firestore";
+import { toggleFavorite } from "./getProducts";
+import { onAuthReady } from "./authentication.js";
+import { showAlert } from "./general";
 
 const params = new URLSearchParams(window.location.search);
 const storeId = params.get("id");
@@ -35,26 +44,8 @@ async function fetchStoreName(storeId) {
   return "";
 }
 
-// Get store data synchronously
-async function init() {
-  const storesData = await getStores();
-  if (storesData && storesData.length > 0) {
-    displayStores(storesData);
-  } else {
-    console.log("No store data");
-  }
-
-  if (storeId) {
-    const storeName = await fetchStoreName(storeId);
-    getProducts(storeId, storeName);
-    switchView(false); // Show products only
-  }
-}
-
-init();
-
 // Display stores in dynamically made cards
-function displayStores(stores) {
+function displayStores(stores, userID, favorites) {
   const container = document.getElementById("store-cards-container");
 
   container.innerHTML = "";
@@ -77,7 +68,7 @@ function displayStores(stores) {
     storeCardElement.addEventListener("click", () => {
       const storeId = storeCardElement.dataset.storeId;
       const storeName = storeCardElement.dataset.storeName;
-      getProducts(storeId, storeName);
+      getProducts(storeId, storeName, userID, favorites);
     });
 
     container.appendChild(storeCardElement);
@@ -109,7 +100,7 @@ function switchView(showStores) {
 }
 
 // Get store product data
-async function getProducts(storeId, storeName) {
+async function getProducts(storeId, storeName, userID, favorites) {
   document.getElementById(
     "store-name-header"
   ).textContent = `${storeName} Products`;
@@ -123,7 +114,7 @@ async function getProducts(storeId, storeName) {
         ...doc.data(),
       };
     });
-    displayProducts(productArray);
+    displayProducts(productArray, userID, favorites);
     // Switch view to product
     switchView(false);
   } catch (error) {
@@ -132,15 +123,16 @@ async function getProducts(storeId, storeName) {
 }
 
 // Display product
-function displayProducts(products) {
+function displayProducts(products, userID, favorites) {
   const container = $("#product-cards-container");
   container.empty();
 
   products.forEach((product) => {
+    const productID = product.id;
     const $productCard = $(`
         <a href="/product?id=${product.id}" class="hover:cursor-pointer border border-gray-300 rounded-md flex flex-col relative">
           <div class="absolute right-3 top-3 text-red-500" data-favorite>
-            <i class="fa-regular fa-heart fa-xl"></i>
+            <i id="save-${productID}" class="fa-regular fa-heart fa-xl"></i>
           </div>
 
           <div class="flex items-center justify-center grow-1">
@@ -161,23 +153,17 @@ function displayProducts(products) {
           </div>
         </a>
         `);
-
     // add to favorite
-    $productCard.on("click", "[data-favorite]", function (e) {
+    $productCard.on("click", "[data-favorite]", async function (e) {
       e.preventDefault();
-      // TODO: add to favorite function here 🔥
+      // TODO: add to favorite function here
+      const isFavorited = await toggleFavorite(userID, doc.id);
+      if (isFavorited) {
+        showAlert("Product was added to favorites!");
+      } else {
+        showAlert("Product was removed from favorites!");
+      }
     });
-
-    // hover on add to favorite
-    $productCard.on("mouseenter", "[data-favorite]", function () {
-      $(this).find(".fa-heart").addClass("fa-solid");
-      $(this).find(".fa-heart").removeClass("fa-regular");
-    });
-    $productCard.on("mouseleave", "[data-favorite]", function () {
-      $(this).find(".fa-heart").addClass("fa-regular");
-      $(this).find(".fa-heart").removeClass("fa-solid");
-    });
-
     // add to current list
     $productCard.on("click", "[data-add-to-list]", async function (e) {
       e.preventDefault();
@@ -187,5 +173,29 @@ function displayProducts(products) {
     container.append($productCard);
   });
 }
+
+function setup() {
+  onAuthReady(async (user) => {
+    const userID = user.uid;
+    const userRef = doc(db, "users", user.uid);
+    const userDoc = await getDoc(userRef);
+    const userData = userDoc.exists() ? userDoc.data() : {};
+    const favorites = userData.favorites || [];
+
+    const storesData = await getStores();
+    if (storesData && storesData.length > 0) {
+      displayStores(storesData, userID, favorites);
+    } else {
+      console.log("No store data");
+    }
+
+    if (storeId) {
+      const storeName = await fetchStoreName(storeId);
+      getProducts(storeId, storeName, userID, favorites);
+      switchView(false); // Show products only
+    }
+  });
+}
+setup();
 
 window.switchView = switchView;

--- a/src/store.js
+++ b/src/store.js
@@ -157,7 +157,7 @@ function displayProducts(products, userID, favorites) {
     $productCard.on("click", "[data-favorite]", async function (e) {
       e.preventDefault();
       // TODO: add to favorite function here
-      const isFavorited = await toggleFavorite(userID, doc.id);
+      const isFavorited = await toggleFavorite(userID, product.id);
       if (isFavorited) {
         showAlert("Product was added to favorites!");
       } else {


### PR DESCRIPTION
Add favorites logic to hearts for homepage, store products and search products 

removed favorite hearts from display previous list since product ID not present in past list firestore data, can add later back in later if have time 
todo: add page showing favorites
